### PR TITLE
refactor(model-factory): 支持 action 配置为可选参数时，调用 payload 参数也可为可选

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # `ekit`
 
 hello, ekit
+
+## bootstrap
+
+1. npm i
+2. sh build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 set -e
-pks="utils jest-config event-center event ajax actions tkit model-factory redux-model use-model model async editor pagination use-fetch eslint-config-tkit scripts service"
+pks="utils jest-config event-center event ajax actions tkit model-factory redux-model use-model model async editor pagination use-fetch eslint-config-tkit scripts service typescript-type-tester"
 
 for p in $pks; do
   if [ -d packages/$p ]; then

--- a/packages/actions/__tests__/__snapshots__/actions.spec.ts.snap
+++ b/packages/actions/__tests__/__snapshots__/actions.spec.ts.snap
@@ -6,7 +6,7 @@ Array [
     "category": 1,
     "code": 2322,
     "fileName": "__tests__/actionsSamples/actionsFail.ts",
-    "messageText": "Type '(username: number) => { payload: { username: number; }; error?: boolean; type: string; }' is not assignable to type '(username: Store['username']) => { type: string; payload: { username: string; }; }'.
+    "messageText": "Type '(username: number) => { payload: { username: number; }; error?: boolean | undefined; type: string; }' is not assignable to type '(username: Store['username']) => { type: string; payload: { username: string; }; }'.
   Types of parameters 'username' and 'username' are incompatible.
     Type 'string' is not assignable to type 'number'.",
   },

--- a/packages/typescript-type-tester/src/typescript-type-tester.ts
+++ b/packages/typescript-type-tester/src/typescript-type-tester.ts
@@ -14,10 +14,19 @@ export const parser = (
 ) => {
   /** 当前执行脚本的目录 */
   const cwd = process.cwd();
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { compilerOptions: rootCompilerOptions } = require(path.join(
+    cwd,
+    '../typescript-config/',
+    'tsconfig.json'
+  ));
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { compilerOptions } = require(path.join(cwd, 'tsconfig.json'));
+
   const fileNameMap: { [file: string]: any[] } = {};
   const errorMap: { [file: string]: any[] } = {};
+
   const program = ts.createProgram(
     files.map((file) => {
       const p = path.join(directory, file);
@@ -25,9 +34,13 @@ export const parser = (
       return p;
     }),
     {
+      ...rootCompilerOptions,
       ...compilerOptions,
       ...runtimeCompilerOptions,
       moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES5,
+      jsx: ts.JsxEmit.React,
     }
   );
   const allDiagnostics = ts.getPreEmitDiagnostics(program);

--- a/packages/typescript-type-tester/src/typescript-type-tester.ts
+++ b/packages/typescript-type-tester/src/typescript-type-tester.ts
@@ -5,6 +5,7 @@ import * as ts from 'typescript';
  * 解析一个 .ts 文件并返回错误信息
  * @param files 文件名
  * @param directory 绝对路径
+ * @param runtimeCompilerOptions 运行时额外的配置项，默认 {}
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const parser = (
@@ -14,15 +15,8 @@ export const parser = (
 ) => {
   /** 当前执行脚本的目录 */
   const cwd = process.cwd();
-
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { compilerOptions: rootCompilerOptions } = require(path.join(
-    cwd,
-    '../typescript-config/',
-    'tsconfig.json'
-  ));
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { compilerOptions } = require(path.join(cwd, 'tsconfig.json'));
+  const configJSON = require(path.join(cwd, 'tsconfig.json'));
+  const { options } = ts.parseJsonConfigFileContent(configJSON, ts.sys, cwd);
 
   const fileNameMap: { [file: string]: any[] } = {};
   const errorMap: { [file: string]: any[] } = {};
@@ -34,13 +28,9 @@ export const parser = (
       return p;
     }),
     {
-      ...rootCompilerOptions,
-      ...compilerOptions,
+      ...options,
       ...runtimeCompilerOptions,
       moduleResolution: ts.ModuleResolutionKind.NodeJs,
-      module: ts.ModuleKind.CommonJS,
-      target: ts.ScriptTarget.ES5,
-      jsx: ts.JsxEmit.React,
     }
   );
   const allDiagnostics = ts.getPreEmitDiagnostics(program);


### PR DESCRIPTION
1. 支持 action 配置为可选参数时，调用 payload 参数也可为可选
2. 更新部分测试用例
3. 修正 typescript-type-tester parser 中的 compilerOptions